### PR TITLE
Add support for Laravel Lumen framework

### DIFF
--- a/src/LaravelDarkSkyServiceProvider.php
+++ b/src/LaravelDarkSkyServiceProvider.php
@@ -15,7 +15,11 @@ class LaravelDarkSkyServiceProvider extends ServiceProvider
     {
         $source = dirname(__DIR__).'/config/darksky.php';
 
-        $this->publishes([$source => config_path('darksky.php')]);
+        if ($this->app instanceof LaravelApplication) {
+            $this->publishes([$source => config_path('darksky.php')]);
+        } elseif ($this->app instanceof LumenApplication) {
+            $this->app->configure('darksky');
+        }
 
         $this->mergeConfigFrom($source, 'darksky');
     }


### PR DESCRIPTION
I was trying to use this in a Lumen project but config_path doesn't exist in Lumen's helpers. This code change should allow for both Laravel and Lumen projects. I borrowed this logic from https://github.com/aws/aws-sdk-php-laravel/blob/master/src/AwsServiceProvider.php