### PR TITLE
Set minimum Laravel version to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4.0",
         "guzzlehttp/guzzle": "~5.3|~6.0",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.*"
+        "illuminate/support": "~5.3"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"


### PR DESCRIPTION
Tbh, I don't see the point in having to add support for each new Laravel version. This package only makes use of basic Laravel APIs and it should be fine to just set a minimum version of 5.3.