### PR TITLE
Added Laravel 6.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+### Composer ###
+composer.lock
+/vendor/
+
+### PhpStorm ###
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Require this package with composer using the following command:
 $ composer require naughtonium/laravel-dark-sky
 ```
 
+In Laravel 5.5, [service providers and aliases are automatically registered](https://laravel.com/docs/6.0/packages#package-discovery). Or you may manually add the service provider and aliases in your config/app.php file.
 
-After updating composer, add the service provider to the `providers` array in `config/app.php`
-
+Add a new item to the `providers` array in `config/app.php`:
 ```php
 Naughtonium\LaravelDarkSky\LaravelDarkSkyServiceProvider::class,
 ```
 
-To register a facade accessor, add the following to `config/app.php` `aliases` array
+Add a new item to the `aliases` array in `config/app.php`:
 ```php
 'DarkSky' => \Naughtonium\LaravelDarkSky\Facades\DarkSky::class,
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "illuminate/support": "~5.5|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "6.*"
+        "phpunit/phpunit": "6.*",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4.0",
         "guzzlehttp/guzzle": "~5.3|~6.0",
-        "illuminate/support": "~5.3"
+        "illuminate/support": "~5.3|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.3|~6.0",
-        "illuminate/support": "~5.3|^6.0"
+        "php": ">=7.0.0",
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "~5.5|~6.0",
+        "illuminate/support": "~5.5|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*"
+        "phpunit/phpunit" : "6.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/DarkSky.php
+++ b/src/DarkSky.php
@@ -8,7 +8,6 @@
 
 namespace Naughtonium\LaravelDarkSky;
 
-
 class DarkSky
 {
     protected $apiKey;
@@ -140,7 +139,7 @@ class DarkSky
 
     /**
      * Filters out metadata to get only currently
-     * 
+     *
      * @return $this
      */
     public function currently()

--- a/src/Facades/DarkSky.php
+++ b/src/Facades/DarkSky.php
@@ -10,6 +10,8 @@ class DarkSky extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor() { return 'darksky'; }
-
+    protected static function getFacadeAccessor()
+    {
+        return 'darksky';
+    }
 }

--- a/src/LaravelDarkSkyServiceProvider.php
+++ b/src/LaravelDarkSkyServiceProvider.php
@@ -27,8 +27,7 @@ class LaravelDarkSkyServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('darksky',function($app)
-        {
+        $this->app->singleton('darksky', function ($app) {
             return new DarkSky();
         });
     }


### PR DESCRIPTION
- added Laravel 6.x compatibility
- added .gitignore
- set minimum Laravel version to 5.5
- set minimum PHP version to 7.0
- set PHPUnit version to 6.*
- require ext-json
- fixed PSR2 errors
- updated install doc
